### PR TITLE
Make react-mini-router-hook be more compatible with react-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,21 @@ export default function NavBar() {
   return (
     <ul>
       <li onClick={() => setPath('/users/1')}>Menu Item 1</li>
-      <li onClick={() => setPath('/users/2')}>Menu Item 1</li>
+      <li onClick={() => setPath('/users/2')}>Menu Item 2</li>
+  <ul>);
+}
+```
+
+### Using links (react-router style)
+
+```js
+import { Link } from 'react-mini-router-hook';
+
+export default function NavBar() {
+  return (
+    <ul>
+      <li><Link to="/users/1">Menu Item 1</Link></li>
+      <li><Link to="/users/1">Menu Item 2</Link></li>
   <ul>);
 }
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,16 @@
+declare module 'react-mini-router-hook' {
+    declare interface RouterProps {
+        location?: string
+    }
+
+    declare interface RouteProps {
+        path: string
+        component?: React.Component<any, any, any> | React.FC | React.ReactElement | React.ClassType<any, any, any> 
+        children?: React.ReactChild
+    }
+
+    const Router: React.FC<RouterProps> = props => {}
+    const Route: React.FC<RouteProps> = props => {}
+    const RouterContext: React.Context<{ path: string; setPath: (path: string) => void }>
+    const Link: React.FC<{ to: string } & React.HTMLAttributes<HTMLAnchorElement>> = props => {}
+}

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "react-mini-router-hook",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Mini Router for React using hooks",
   "main": "dist/index.js",
   "dependencies": {
     "path-to-regexp": "^2.4.0"
   },
   "peerDependencies": {
-    "react": "^16.7.0-alpha.2",
-    "react-dom": "^16.7.0-alpha.2"
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",

--- a/src/routeBuild.js
+++ b/src/routeBuild.js
@@ -1,23 +1,28 @@
+import React from 'react'
 
 const Regexp = require('path-to-regexp');
 
-export default function RouteBuild (routes) {
-  return function routeBuild (location, props) {
-    props = props || {};
-    const params = {};
+function normalizePath(path, location) {
+  if (!path) return location || '/';
+  if (path[0] === '/') return path;
+  if (parent == null) return path;
+  return `location/${ path }`;
+}
 
-    for (const route in routes) {
-      const m = match(route, params, location);
-      const fn = routes[route];
+export default function RenderRoute(route, routePath, currentPath, location) {
+  const params = {};
 
-      if (m) {
-        if (typeof fn !== 'function') return fn;
-        return fn(params, props);
-      }
+  const m = match(normalizePath(routePath, location), params, currentPath);
+
+  if (m) {
+    if (typeof route !== 'function') {
+      return route;
     }
 
-    return null;
-  };
+    return React.createElement(route, params);
+  }
+
+  return null;
 }
 
 function match(path, params, pathname) {
@@ -31,7 +36,10 @@ function match(path, params, pathname) {
   for (let i = 1, len = m.length; i < len; ++i) {
     const key = keys[i - 1];
     const val = typeof m[i] === 'string' ? decodeURIComponent(m[i]) : m[i];
-    if (key) params[key.name] = val;
+    if (key) {
+      // TODO: fix mutation of input parameter
+      params[key.name] = val;
+    }
   }
 
   return true;


### PR DESCRIPTION
To have better drop-in replacement for react-router i have made the following changes:
- <Route> no longer needs to be direct child of <Router> - as long as it has a context, it will work, this also simplifies code a lot as we no longer have to keep track of all the routes, they keep track of themselves now
- Added <Link to="/path"> component 
- Added typescript definitions

All the changes should be backward compatible.